### PR TITLE
Update Makefile.am

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,83 +1,75 @@
-# lib/Makefile.am
+## lib/Makefile.am
 
-# Copyright (C) 2025 Ivan Guerreschi
-
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# Include custom make rules for flymake
+## Include custom flymake rules
 include $(top_srcdir)/flymake.mk
 
-# Library definition
+## Optionally, build as a shared library with libtool:
+if BUILD_STATIC_ONLY
 noinst_LIBRARIES = libspielterminal.a
-
-# Headers
-noinst_HEADERS = \
-	info.h \
-	user_input.h \
-	$(NULL)
-
-# Library sources
 libspielterminal_a_SOURCES = \
-	info.c \
-	user_input.c \
-	$(noinst_HEADERS) \
-	$(NULL)
-
-# Additional include paths
+    info.c \
+    user_input.c
 libspielterminal_a_CPPFLAGS = \
-	-I$(top_srcdir)/lib \
-	$(NULL)
+    -I$(top_srcdir)/lib
+else
+## Build a shared library using libtool
+lib_LTLIBRARIES = libspielterminal.la
+libspielterminal_la_SOURCES = \
+    info.c \
+    user_input.c
+libspielterminal_la_CPPFLAGS = \
+    -I$(top_srcdir)/lib
+## If you want to explicitly enable/disable shared or static
+libspielterminal_la_LDFLAGS = -version-info 1:0:0
+endif
 
-# Compiler warnings and debug flags
+## Development warnings and debug flags
 AM_CFLAGS = \
-	-Wall \
-	-Wextra \
-	-Wdouble-promotion \
-	-Wformat-security \
-	-Wformat-signedness \
-	-Winit-self \
-	-Wshift-overflow=2 \
-	-Wswitch-default \
-	-Wstrict-overflow=4 \
-	-Warith-conversion \
-	-Wduplicated-branches \
-	-Wduplicated-cond \
-	-Wshadow \
-	-Wcast-qual \
-	-Wconversion \
-	-Wdate-time \
-	-Wstrict-prototypes \
-	-Wmissing-prototypes \
-	-Winvalid-pch \
-	-Wredundant-decls \
-	-Wformat-nonliteral \
-	$(NULL)
+    -Wall \
+    -Wextra \
+    -Wdouble-promotion \
+    -Wformat-security \
+    -Wformat-signedness \
+    -Winit-self \
+    -Wshift-overflow=2 \
+    -Wswitch-default \
+    -Wstrict-overflow=4 \
+    -Warith-conversion \
+    -Wduplicated-branches \
+    -Wduplicated-cond \
+    -Wshadow \
+    -Wcast-qual \
+    -Wconversion \
+    -Wdate-time \
+    -Wstrict-prototypes \
+    -Wmissing-prototypes \
+    -Winvalid-pch \
+    -Wredundant-decls \
+    -Wformat-nonliteral \
+    -ggdb
 
-# Debug flags
-AM_CFLAGS += -ggdb
+## If coverage is enabled from configure
+if ENABLE_COVERAGE
+AM_CFLAGS += -fprofile-arcs -ftest-coverage
+AM_LDFLAGS += -fprofile-arcs -ftest-coverage
+endif
 
-# Clean generated files
+## Headers remain private for now
+noinst_HEADERS = info.h user_input.h
+
+## Cleaning rules
 CLEANFILES = \
-	*~ \
-	*.bak \
-	*.o \
-	*.a \
-	core \
-	*.core \
-	$(NULL)
+    *~ \
+    *.bak \
+    *.o \
+    *.lo \
+    *.la \
+    *.a \
+    core \
+    *.core
 
-# Maintainer clean
 MAINTAINERCLEANFILES = \
-	Makefile.in \
-	$(NULL)
+    Makefile.in
+
+## Optionally define 'check' or 'lint' targets if needed
+## e.g. 'make lint' using flymake or other static checks.


### PR DESCRIPTION
1. Verify Understanding You’ve provided a Makefile.am from an Automake-based project that builds a static library named libspielterminal.a. The snippet defines compiler warnings and debug flags, includes some local headers, and uses a custom flymake.mk. It also features standard Automake cleanup rules and a MAINTAINERCLEANFILES section for maintainers.

The goal is presumably to ensure your library code (info.c, user_input.c, etc.) is compiled correctly with robust warning flags, and to manage the build/clean lifecycle using Automake conventions. You might be interested in how to structure the Automake file for best practices or how to expand it for future needs such as installing headers, enabling coverage, or building shared libraries.

2. Outline Approach Analyze Current Setup: Review the existing content—compilation flags, library definition, header management, cleaning rules, etc. Identify Potential Improvements: Suggest ways to refine, such as adding install targets, handling optional shared libraries, or customizing your compiler flags further. Demonstrate Example Refinements: Provide an updated Makefile.am snippet illustrating typical enhancements, like coverage instrumentation or optional shared libraries. Explain Rationale: Clarify why each improvement helps with maintainability, extensibility, or best practice compliance in Automake-based projects.
3. Critique & Best Practice Suggestions 3.1 Library Definition
Static vs. Shared: Currently, you define noinst_LIBRARIES = libspielterminal.a, which means the library isn’t installed and is statically built. If you need to install and use this library elsewhere, you’d typically switch to lib_LTLIBRARIES (if using Libtool) or lib_LIBRARIES. Libtool Support: If you want to support multiple platforms or produce both static and shared libs, consider using Libtool and naming the library something like libspielterminal.la. For example: makefile
Copy code
lib_LTLIBRARIES = libspielterminal.la
libspielterminal_la_SOURCES = info.c user_input.c ... Then you can choose build flags like -static or -shared automatically. 3.2 Header Management
Installation: Because you have noinst_HEADERS, these headers remain internal. If you eventually want to expose them to other projects, you’d use include_HEADERS or pkginclude_HEADERS for user-installable headers. 3.3 Compiler Flags
AM_CFLAGS: You already have an extensive set of warnings, which is excellent. You might also consider: -pedantic to enforce strict C standard compliance. -Wvla to warn about variable-length arrays.
-Werror in development scenarios if you want warnings to be treated as errors (though this can be too strict for production). Per-Target Flags: If certain flags only apply to the library, you can do: makefile
Copy code
libspielterminal_a_CFLAGS = $(AM_CFLAGS) -Wno-something to add or remove flags for that specific target.
3.4 Coverage / Profiling
Enabling Coverage: If you want code coverage, you could have a configure option to append -fprofile-arcs -ftest-coverage or a --enable-coverage option that sets GCOV flags. For instance: makefile
Copy code
if ENABLE_COVERAGE
AM_CFLAGS += -fprofile-arcs -ftest-coverage
AM_LDFLAGS += -fprofile-arcs -ftest-coverage
endif
This is typically paired with an AC_ARG_ENABLE([coverage], ...) in configure.ac. 3.5 Cleaning Rules
Custom CLEANFILES: You already list *~, *.bak, object files, libraries, and core dumps, which covers a lot. If you generate additional files (e.g., coverage .gcda/.gcno files), you might add them: makefile
Copy code
CLEANFILES += \
  *.gcda \
  *.gcno
Dist vs. Maintainer Clean: Automake automatically handles some “dist” files (like .in files). You’re using MAINTAINERCLEANFILES for Makefile.in, which is standard. 3.6 Integrating flymake.mk
flymake.mk: Since you have a custom flymake.mk included, ensure it’s robust for linting or syntax checks. Typically, you might pass additional flags or incorporate a lint target. For instance: makefile
Copy code
include $(top_srcdir)/flymake.mk

# Possibly define a 'make lint' or 'make check-syntax' target lint:
    $(FLYMAKE) $(some_variable)
3.7 Example of Extended Makefile.am
Below is a condensed example showing how you might refine your setup to optionally build a shared library, support coverage, and maintain your custom flags. This is purely illustrative:

makefile
Copy code
## lib/Makefile.am

## Include custom flymake rules
include $(top_srcdir)/flymake.mk

## Optionally, build as a shared library with libtool: if BUILD_STATIC_ONLY
noinst_LIBRARIES = libspielterminal.a
libspielterminal_a_SOURCES = \
    info.c \
    user_input.c
libspielterminal_a_CPPFLAGS = \
    -I$(top_srcdir)/lib
else
## Build a shared library using libtool
lib_LTLIBRARIES = libspielterminal.la
libspielterminal_la_SOURCES = \
    info.c \
    user_input.c
libspielterminal_la_CPPFLAGS = \
    -I$(top_srcdir)/lib
## If you want to explicitly enable/disable shared or static libspielterminal_la_LDFLAGS = -version-info 1:0:0
endif

## Development warnings and debug flags
AM_CFLAGS = \
    -Wall \
    -Wextra \
    -Wdouble-promotion \
    -Wformat-security \
    -Wformat-signedness \
    -Winit-self \
    -Wshift-overflow=2 \
    -Wswitch-default \
    -Wstrict-overflow=4 \
    -Warith-conversion \
    -Wduplicated-branches \
    -Wduplicated-cond \
    -Wshadow \
    -Wcast-qual \
    -Wconversion \
    -Wdate-time \
    -Wstrict-prototypes \
    -Wmissing-prototypes \
    -Winvalid-pch \
    -Wredundant-decls \
    -Wformat-nonliteral \
    -ggdb

## If coverage is enabled from configure
if ENABLE_COVERAGE
AM_CFLAGS += -fprofile-arcs -ftest-coverage
AM_LDFLAGS += -fprofile-arcs -ftest-coverage
endif

## Headers remain private for now
noinst_HEADERS = info.h user_input.h

## Cleaning rules
CLEANFILES = \
    *~ \
    *.bak \
    *.o \
    *.lo \
    *.la \
    *.a \
    core \
    *.core

MAINTAINERCLEANFILES = \
    Makefile.in

## Optionally define 'check' or 'lint' targets if needed ## e.g. 'make lint' using flymake or other static checks. In practice, you’d also adjust configure.ac to set BUILD_STATIC_ONLY or ENABLE_COVERAGE based on command-line arguments (./configure --enable-coverage) or environment checks.

4. Final Thoughts & Recommendations Keep or Remove Unused Flags: If you find some warnings are too verbose, feel free to remove or temporarily disable them. Libtool: If portability to many platforms (Windows, macOS, Linux) is desired, strongly consider using Libtool to handle library creation. Optional Installation: If your library eventually becomes public for consumption by other projects, switch from noinst_LIBRARIES to lib_LIBRARIES or lib_LTLIBRARIES, and consider installing headers via include_HEADERS. Coverage & Testing: Add a check target in Automake to run unit tests, enabling coverage instrumentation for thorough test coverage analysis. This Makefile.am is already quite solid—covering thorough warnings, debug info, and housekeeping. By refining it to handle various build scenarios (coverage, optional shared libs, or installed headers), you can future-proof your project as needs evolve.